### PR TITLE
Add a setup.py for easy_install / pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+try:
+    from setuptools import setup, find_packages
+except ImportError:
+    from ez_setup import use_setuptools
+    use_setuptools()
+    from setuptools import setup, find_packages
+
+setup(
+    name='SourceLib',
+    description='Python implementation of Valve Source Dedicated Server Query/RCON/Log protocols.',
+    version="0.0.1",
+    author='',
+    author_email='',
+    url='https://github.com/frostschutz/SourceLib',
+    packages=['SourceLib'],
+    package_dir = {'SourceLib': '.'}
+)


### PR DESCRIPTION
I've added a bare setup.py for using with pip.
I didn't want to fill in your details based on guesses, so I've left author and author_email empty.
